### PR TITLE
Fix server setup safety and docker tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,18 +85,18 @@
 请使用 `root` 或具有 `sudo` 权限的用户执行：
 
 ```bash
-/bin/bash <(wget -qO - [https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh](https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh))
-````
+/bin/bash <(wget -qO - https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh)
+```
 
 **备用链接与国内加速:**
 
 ```bash
 # 短链接
 /bin/bash <(wget -qO - bit.ly/ls-set)
-/bin/bash <(wget -qO - [https://tinyurl.com/server-setup](https://tinyurl.com/server-setup))
+/bin/bash <(wget -qO - https://tinyurl.com/server-setup)
 
 # 国内服务器专用加速
-/bin/bash <(wget -qO - [https://mirror.ghproxy.com/https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh](https://mirror.ghproxy.com/https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh))
+/bin/bash <(wget -qO - https://mirror.ghproxy.com/https://raw.githubusercontent.com/SuperNG6/linux-setup.sh/main/server-setup.sh)
 ```
 
 启动后，根据菜单提示输入数字选择相应功能即可。

--- a/add_docker_tools.sh
+++ b/add_docker_tools.sh
@@ -98,11 +98,28 @@ alias dc="bash ${tools_dir}/dc.sh"
 alias dcs="bash ${tools_dir}/dcstats.sh"
 alias dcps="bash ${tools_dir}/dcps.sh"
 alias dcip="bash ${tools_dir}/dcip.sh"
-alias dlogs="bash ${tools_dir}/dlogs.sh"
 alias dclogs="bash ${tools_dir}/dclogs.sh"
 alias dr="bash ${tools_dir}/drestart.sh"
 alias dcr="bash ${tools_dir}/dcrestart.sh"
-alias dexec="bash ${tools_dir}/dexec.sh"
+
+unalias dlogs dexec 2>/dev/null
+
+dlogs() {
+    bash "${tools_dir}/dlogs.sh" "\$@"
+}
+
+dexec() {
+    bash "${tools_dir}/dexec.sh" "\$@"
+}
+
+_docker_tools_container_names() {
+    local current="\${COMP_WORDS[COMP_CWORD]}"
+    local containers
+    containers=\$(docker ps --format '{{.Names}}' 2>/dev/null)
+    mapfile -t COMPREPLY < <(compgen -W "\$containers" -- "\$current")
+}
+
+complete -F _docker_tools_container_names dlogs dexec
 EOF
 
     # --- 使用循环下载其余的脚本，并进行错误检查 ---

--- a/configure_fail2ban.sh
+++ b/configure_fail2ban.sh
@@ -77,7 +77,8 @@ check_fail2ban_available() {
 
 # 检测并修复日志配置
 setup_logging() {
-    local os_type=$(get_os_info)
+    local os_type
+    os_type=$(get_os_info)
     
     echo "🔍 正在检查系统日志配置..."
     
@@ -118,8 +119,9 @@ setup_logging() {
 
 # 检测 SSH 日志文件路径
 detect_ssh_log_path() {
-    local os_type=$(get_os_info)
+    local os_type
     local possible_logs=()
+    os_type=$(get_os_info)
     
     case $os_type in
         "Debian/Ubuntu")
@@ -146,7 +148,8 @@ detect_ssh_log_path() {
 
 # 安装 Fail2ban
 install_fail2ban() {
-    local os_type=$(get_os_info)
+    local os_type
+    os_type=$(get_os_info)
     
     echo "正在检查 Fail2ban 是否已安装..."
     
@@ -244,16 +247,19 @@ generate_fail2ban_config() {
     local ban_time_hours=$3
     
     local ban_time_seconds=$((ban_time_hours * 3600))
-    local jail_local="/etc/fail2ban/jail.local"
+    local jail_local="/etc/fail2ban/jail.d/sshd-linux-setup.local"
     local custom_comment="# SSH protection configured by fail2ban.sh script"
-    local log_path=$(detect_ssh_log_path)
-    local os_type=$(get_os_info)
+    local log_path
+    log_path=$(detect_ssh_log_path)
     
     echo "🔧 正在生成 Fail2ban 配置..."
     
-    # 备份现有配置（如果存在）
+    mkdir -p /etc/fail2ban/jail.d
+
+    # 只备份脚本管理的配置（如果存在），避免覆盖用户自己的 jail.local。
     if [ -f "$jail_local" ]; then
-        local backup_file="${jail_local}.bak.$(date +%Y%m%d_%H%M%S)"
+        local backup_file
+        backup_file="${jail_local}.bak.$(date +%Y%m%d_%H%M%S)"
         echo "📦 备份现有配置到: $backup_file"
         cp "$jail_local" "$backup_file"
     fi
@@ -399,7 +405,7 @@ verify_configuration() {
     echo "   • 请确保您的 IP 地址不会被误封"
     echo "   • 可以使用 'fail2ban-client status sshd' 查看状态"
     echo "   • 可以使用 'fail2ban-client unban IP地址' 解封特定IP"
-    echo "   • 配置文件位置: /etc/fail2ban/jail.local"
+    echo "   • 配置文件位置: /etc/fail2ban/jail.d/sshd-linux-setup.local"
     echo "   • 查看日志: journalctl -u fail2ban -f"
 }
 

--- a/docker_tools/dc.sh
+++ b/docker_tools/dc.sh
@@ -10,11 +10,8 @@ check_docker_compose_version
 # 文件夹选择
 select_docker_compose_dir
 
-# 构建命令,将所有传入的参数添加到$compose_cmd后
-full_command="$compose_cmd ${@}"
-
-# 执行构建的命令
-eval $full_command
+# 执行 docker compose 命令，保留参数边界，避免 eval 注入风险。
+run_docker_compose "$@"
 
 # 检查命令是否执行成功
 if [ $? -ne 0 ]; then

--- a/docker_tools/dclogs.sh
+++ b/docker_tools/dclogs.sh
@@ -11,6 +11,7 @@ check_docker_compose_version
 select_docker_compose_dir
 
 # 显示docker-compose信息
+# shellcheck disable=SC2154 # selected_folder/compose_cmd 由 docker_utils.sh 设置
 echo "正在检查 $selected_folder 的 $compose_cmd 容器信息..."
 $compose_cmd logs -f -n 10
 

--- a/docker_tools/dcps.sh
+++ b/docker_tools/dcps.sh
@@ -11,6 +11,7 @@ check_docker_compose_version
 select_docker_compose_dir
 
 # 显示docker-compose信息
+# shellcheck disable=SC2154 # selected_folder/compose_cmd 由 docker_utils.sh 设置
 echo "正在检查 $selected_folder 的 $compose_cmd 容器信息..."
 $compose_cmd ps
 

--- a/docker_tools/dcrestart.sh
+++ b/docker_tools/dcrestart.sh
@@ -22,6 +22,7 @@ while getopts "rR" opt; do
       ;;
     \? )
       echo "用法: $0 [-r] [-R]"
+      # shellcheck disable=SC2154 # compose_cmd 由 docker_utils.sh 设置
       echo "  -r: 快速重启 (默认, 使用 $compose_cmd restart)"
       echo "  -R: 完全重建 (使用 $compose_cmd down 和 up)"
       exit 1

--- a/docker_tools/dcstats.sh
+++ b/docker_tools/dcstats.sh
@@ -11,6 +11,7 @@ check_docker_compose_version
 select_docker_compose_dir
 
 # 显示$compose_cmd状态
+# shellcheck disable=SC2154 # selected_folder/compose_cmd 由 docker_utils.sh 设置
 echo "正在检查 $selected_folder 的 $compose_cmd 容器状态..."
 $compose_cmd stats
 

--- a/docker_tools/dexec.sh
+++ b/docker_tools/dexec.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # 引用docker_utils脚本
 source "${SCRIPT_DIR}/docker_utils.sh"
 
-# 选择容器并获取容器名
-container=$(select_container "请选择要进入的容器：")
+# 选择容器并获取容器名；支持命令行参数传入编号或容器名。
+container=$(container_arg_or_select "$1" "请选择要进入的容器：") || exit 1
 
 echo "正在尝试进入容器 ${container}..."
 

--- a/docker_tools/dlogs.sh
+++ b/docker_tools/dlogs.sh
@@ -5,8 +5,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # 引用docker_utils脚本
 source "${SCRIPT_DIR}/docker_utils.sh"
 
-# 选择容器
-container=$(select_container "请选择要查看日志的容器：")
+# 选择容器；支持命令行参数传入编号或容器名。
+container=$(container_arg_or_select "$1" "请选择要查看日志的容器：") || exit 1
 
 # 执行docker命令查看日志
 docker logs -f -n10 "${container}"

--- a/docker_tools/docker_aliases.sh
+++ b/docker_tools/docker_aliases.sh
@@ -6,8 +6,25 @@ alias dc="bash /root/.docker_tools/dc.sh"
 alias dcs="bash /root/.docker_tools/dcstats.sh"
 alias dcps="bash /root/.docker_tools/dcps.sh"
 alias dcip="bash /root/.docker_tools/dcip.sh"
-alias dlogs="bash /root/.docker_tools/dlogs.sh"
 alias dclogs="bash /root/.docker_tools/dclogs.sh"
 alias dr="bash /root/.docker_tools/drestart.sh"
 alias dcr="bash /root/.docker_tools/dcrestart.sh"
-alias dexec="bash /root/.docker_tools/dexec.sh"
+
+unalias dlogs dexec 2>/dev/null
+
+dlogs() {
+    bash "/root/.docker_tools/dlogs.sh" "$@"
+}
+
+dexec() {
+    bash "/root/.docker_tools/dexec.sh" "$@"
+}
+
+_docker_tools_container_names() {
+    local current="${COMP_WORDS[COMP_CWORD]}"
+    local containers
+    containers=$(docker ps --format '{{.Names}}' 2>/dev/null)
+    mapfile -t COMPREPLY < <(compgen -W "$containers" -- "$current")
+}
+
+complete -F _docker_tools_container_names dlogs dexec

--- a/docker_tools/docker_utils.sh
+++ b/docker_tools/docker_utils.sh
@@ -14,6 +14,14 @@ check_docker_compose_version() {
     fi
 }
 
+run_docker_compose() {
+    if [ "$compose_cmd" = "docker compose" ]; then
+        docker compose "$@"
+    else
+        docker-compose "$@"
+    fi
+}
+
 # 函数：选择Docker Compose目录
 select_docker_compose_dir() {
     # 检查当前目录是否包含docker-compose.yml或docker-compose.yaml
@@ -68,7 +76,8 @@ select_docker_compose_dir() {
 select_container() {
     local prompt="$1"
     local selected_container=""
-    local containers=($(docker ps --format "{{.Names}}"))
+    local containers=()
+    mapfile -t containers < <(docker ps --format "{{.Names}}")
 
     if [ ${#containers[@]} -eq 0 ]; then
         echo "没有正在运行的Docker容器。" >&2
@@ -95,10 +104,18 @@ select_container() {
             else
                 echo "输入的数字无效，请输入 1 到 ${#containers[@]} 之间的数字。" >&2
             fi
-        elif [[ " ${containers[@]} " =~ " ${input} " ]]; then
-            selected_container="$input"
-            break
         else
+            for container in "${containers[@]}"; do
+                if [ "$container" = "$input" ]; then
+                    selected_container="$input"
+                    break
+                fi
+            done
+
+            if [ -n "$selected_container" ]; then
+                break
+            fi
+
             echo "无效的输入。请从下面的列表中选择。" >&2
             echo "可用的容器：" >&2
             for i in "${!containers[@]}"; do
@@ -109,4 +126,50 @@ select_container() {
     done
 
     echo "$selected_container"
+}
+
+resolve_container() {
+    local input="$1"
+    local containers=()
+    mapfile -t containers < <(docker ps --format "{{.Names}}")
+
+    if [ ${#containers[@]} -eq 0 ]; then
+        echo "没有正在运行的Docker容器。" >&2
+        return 1
+    fi
+
+    if [[ "$input" =~ ^[0-9]+$ ]]; then
+        if ((input > 0 && input <= ${#containers[@]})); then
+            echo "${containers[$((input-1))]}"
+            return 0
+        else
+            echo "输入的数字无效，请输入 1 到 ${#containers[@]} 之间的数字。" >&2
+            return 1
+        fi
+    fi
+
+    for container in "${containers[@]}"; do
+        if [ "$container" = "$input" ]; then
+            echo "$container"
+            return 0
+        fi
+    done
+
+    echo "未找到正在运行的容器: $input" >&2
+    echo "可用的容器：" >&2
+    for i in "${!containers[@]}"; do
+        echo "$((i + 1)). ${containers[$i]}" >&2
+    done
+    return 1
+}
+
+container_arg_or_select() {
+    local input="$1"
+    local prompt="$2"
+
+    if [ -n "$input" ]; then
+        resolve_container "$input"
+    else
+        select_container "$prompt"
+    fi
 }

--- a/manage_xanmod_kernel.sh
+++ b/manage_xanmod_kernel.sh
@@ -20,7 +20,7 @@ install_xanmod() {
     debug_echo() {
         if [[ "$DEBUG" == "true" ]]; then
             # 使用 >&2 将调试信息输出到标准错误，不影响管道中的正常输出
-            echo "DEBUG: $@" >&2
+            echo "DEBUG: $*" >&2
         fi
     }
     # --- 调试模式设置结束 ---

--- a/optimize_kernel_parameters.sh
+++ b/optimize_kernel_parameters.sh
@@ -17,6 +17,10 @@
 # ===================================================================================
 
 optimize_kernel_parameters() {
+    is_positive_number() {
+        [[ "$1" =~ ^[0-9]+([.][0-9]+)?$ ]] && awk "BEGIN {exit !($1 > 0)}"
+    }
+
     # 确认操作
     read -p "您确定要优化Linux内核网络与内存参数吗？这将修改 '/etc/sysctl.conf'。 (y/n): " choice
     case "$choice" in
@@ -30,6 +34,7 @@ optimize_kernel_parameters() {
     esac
 
     # --- 步骤 1: 备份原始配置文件 ---
+    backup_file=""
     if [ -f /etc/sysctl.conf ]; then
         backup_file="/etc/sysctl.conf.bak.$(date +%Y%m%d_%H%M%S)"
         echo "--> 正在备份当前配置到: ${backup_file}"
@@ -56,9 +61,14 @@ optimize_kernel_parameters() {
     fi
 
     # 确保输入不为空，提供一个最终的默认值
-    : ${rtt:=170}
-    : ${download_bw:=1000}
-    : ${upload_bw:=100}
+    : "${rtt:=170}"
+    : "${download_bw:=1000}"
+    : "${upload_bw:=100}"
+
+    if ! is_positive_number "$rtt" || ! is_positive_number "$download_bw" || ! is_positive_number "$upload_bw"; then
+        echo "====== [错误] RTT、下载带宽、上传带宽必须是大于 0 的数字。 ======"
+        exit 1
+    fi
 
     # --- 步骤 4: 分别计算下载和上传的BDP (带宽延迟积) ---
     # 下载BDP (接收方向)
@@ -101,7 +111,7 @@ optimize_kernel_parameters() {
     fi
 
     # 根据网络情况计算 tcp_adv_win_scale
-    if [ "$download_bw" -eq "$upload_bw" ]; then
+    if awk "BEGIN {exit !(${download_bw} == ${upload_bw})}"; then
         echo "    [信息] 上下行带宽对等，tcp_adv_win_scale 设为: 1"
         tcp_adv_win_scale=1
     else
@@ -229,8 +239,8 @@ optimize_kernel_parameters() {
 net.ipv4.tcp_congestion_control = bbr
 # 设置默认的网络包调度算法为FQ。
 net.core.default_qdisc = fq
-# 设置：优化拥塞控制行为，减少保守性
-net.ipv4.tcp_moderate_rcvbuf = 0
+# 启用 TCP 接收缓冲区自动调整，适配不同连接的带宽延迟积。
+net.ipv4.tcp_moderate_rcvbuf = 1
 
 # ---- B. 全局套接字缓冲区核心参数 ----
 # 优化：下载优先，上传够用即可
@@ -267,9 +277,6 @@ net.ipv4.tcp_retries1 = 3
 net.ipv4.tcp_retries2 = 10
 # 适度丢包检测
 net.ipv4.tcp_frto = 1
-# 优化：禁用发送缓冲区的自动调整，避免上传波动
-net.ipv4.tcp_moderate_rcvbuf = 1
-
 # ---- D. UDP/QUIC 性能优化 (针对 Hysteria2) ----
 # 设置系统所有UDP套接字可以占用的内存大小(单位: page)。
 net.ipv4.udp_mem = ${udp_mem_min_pages} ${udp_mem_pressure_pages} ${udp_mem_max_pages}
@@ -345,14 +352,19 @@ EOM
     # --- 步骤 11: 应用新的内核参数 ---
     echo "--> 正在应用新的内核参数..."
     # 执行sysctl -p并显示其输出，以便用户确认
-    sysctl -p /etc/sysctl.conf
-    if [ $? -eq 0 ]; then
+    if sysctl -p /etc/sysctl.conf; then
         echo "====== 内核参数优化成功并已生效！ ======"
         echo "====== 配置信息已记录在配置块的注释中，便于后续维护。 ======"
         echo "====== 脏页参数已根据${mem_mb}MB内存进行优化配置。 ======"
         echo "====== 为确保所有网络相关设置完全应用，建议您重启服务器。 ======"
     else
         echo "====== [错误] 应用内核参数时出错，请检查 /etc/sysctl.conf 的语法。 ======"
+        if [ -n "$backup_file" ] && [ -f "$backup_file" ]; then
+            echo "====== 正在从备份恢复 /etc/sysctl.conf: $backup_file ======"
+            cp "$backup_file" /etc/sysctl.conf
+            sysctl -p /etc/sysctl.conf
+        fi
+        return 1
     fi
 }
 

--- a/server-setup.sh
+++ b/server-setup.sh
@@ -18,6 +18,9 @@ FIREWALL_TYPE=""
 # 脚本启动时检查一次操作系统类型，并存入全局变量
 OS_TYPE=""
 
+SSHD_CONFIG="/etc/ssh/sshd_config"
+SSHD_MANAGED_CONFIG="/etc/ssh/sshd_config.d/99-linux-setup.conf"
+
 # --- 基础检查与环境设置 ---
 
 # 检查是否具有足够的权限
@@ -102,6 +105,161 @@ check_firewall() {
 	else
 		echo "unknown"
 	fi
+}
+
+get_ssh_service() {
+	local service
+	for service in sshd ssh; do
+		if systemctl list-unit-files "${service}.service" --no-legend 2>/dev/null | grep -q "^${service}.service"; then
+			echo "$service"
+			return 0
+		fi
+		if systemctl list-units "${service}.service" --all --no-legend 2>/dev/null | grep -q "^${service}.service"; then
+			echo "$service"
+			return 0
+		fi
+	done
+
+	echo ""
+}
+
+validate_ssh_config() {
+	if command -v sshd &>/dev/null; then
+		sshd -t
+	elif [ -x /usr/sbin/sshd ]; then
+		/usr/sbin/sshd -t
+	else
+		echo "错误: 未找到 sshd，无法校验 SSH 配置。" >&2
+		return 1
+	fi
+}
+
+dump_effective_ssh_config() {
+	if command -v sshd &>/dev/null; then
+		sshd -T
+	elif [ -x /usr/sbin/sshd ]; then
+		/usr/sbin/sshd -T
+	else
+		echo "错误: 未找到 sshd，无法读取 SSH 生效配置。" >&2
+		return 1
+	fi
+}
+
+ensure_sshd_dropin_include() {
+	if head -n 1 "$SSHD_CONFIG" | grep -Eiq '^[[:space:]]*Include[[:space:]]+/etc/ssh/sshd_config\.d/\*\.conf'; then
+		return 0
+	fi
+
+	echo "正在将 sshd_config drop-in Include 放到文件顶部，确保脚本管理的配置优先生效。"
+	sed -i '1i Include /etc/ssh/sshd_config.d/*.conf' "$SSHD_CONFIG"
+}
+
+backup_ssh_state() {
+	local backup_dir
+	backup_dir=$(mktemp -d)
+	cp "$SSHD_CONFIG" "${backup_dir}/sshd_config"
+	if [ -f "$SSHD_MANAGED_CONFIG" ]; then
+		cp "$SSHD_MANAGED_CONFIG" "${backup_dir}/managed_config"
+	fi
+	echo "$backup_dir"
+}
+
+restore_ssh_state() {
+	local backup_dir=$1
+
+	if [ -z "$backup_dir" ] || [ ! -d "$backup_dir" ]; then
+		return 1
+	fi
+
+	cp "${backup_dir}/sshd_config" "$SSHD_CONFIG"
+	if [ -f "${backup_dir}/managed_config" ]; then
+		mkdir -p "$(dirname "$SSHD_MANAGED_CONFIG")"
+		cp "${backup_dir}/managed_config" "$SSHD_MANAGED_CONFIG"
+	else
+		rm -f "$SSHD_MANAGED_CONFIG"
+	fi
+}
+
+write_ssh_managed_config() {
+	local new_port=$1
+	local password_mode=$2
+	local existing_port=""
+	local password_disabled=false
+	local final_port
+	local tmp_file
+
+	mkdir -p "$(dirname "$SSHD_MANAGED_CONFIG")"
+
+	if [ -f "$SSHD_MANAGED_CONFIG" ]; then
+		existing_port=$(awk 'tolower($1) == "port" {print $2; exit}' "$SSHD_MANAGED_CONFIG")
+		if grep -Eiq '^[[:space:]]*PasswordAuthentication[[:space:]]+no' "$SSHD_MANAGED_CONFIG"; then
+			password_disabled=true
+		fi
+	fi
+
+	final_port=${new_port:-$existing_port}
+	tmp_file=$(mktemp)
+
+	{
+		echo "# Managed by linux-setup.sh"
+		echo "# Do not edit manually unless you stop using the script."
+		if [ -n "$final_port" ]; then
+			echo "Port $final_port"
+		fi
+		if [ "$password_mode" = "no" ] || { [ "$password_mode" = "keep" ] && [ "$password_disabled" = true ]; }; then
+			echo "PasswordAuthentication no"
+			echo "KbdInteractiveAuthentication no"
+			echo "ChallengeResponseAuthentication no"
+		fi
+	} >"$tmp_file"
+
+	mv "$tmp_file" "$SSHD_MANAGED_CONFIG"
+}
+
+verify_ssh_password_disabled() {
+	local effective_config
+	local password_auth
+	local kbd_auth
+	local challenge_auth
+
+	effective_config=$(dump_effective_ssh_config) || return 1
+	password_auth=$(awk '$1 == "passwordauthentication" {print $2; exit}' <<<"$effective_config")
+	kbd_auth=$(awk '$1 == "kbdinteractiveauthentication" {print $2; exit}' <<<"$effective_config")
+	challenge_auth=$(awk '$1 == "challengeresponseauthentication" {print $2; exit}' <<<"$effective_config")
+
+	if [ "$password_auth" != "no" ]; then
+		echo "错误: SSH 生效配置中 PasswordAuthentication 不是 no。" >&2
+		return 1
+	fi
+	if [ -n "$kbd_auth" ] && [ "$kbd_auth" != "no" ]; then
+		echo "错误: SSH 生效配置中 KbdInteractiveAuthentication 不是 no。" >&2
+		return 1
+	fi
+	if [ -n "$challenge_auth" ] && [ "$challenge_auth" != "no" ]; then
+		echo "错误: SSH 生效配置中 ChallengeResponseAuthentication 不是 no。" >&2
+		return 1
+	fi
+}
+
+verify_ssh_port_effective() {
+	local expected_port=$1
+
+	if ! dump_effective_ssh_config | awk '$1 == "port" {print $2}' | grep -qx "$expected_port"; then
+		echo "错误: SSH 生效配置中未找到端口 $expected_port。" >&2
+		return 1
+	fi
+}
+
+restart_ssh_service() {
+	local ssh_service
+	ssh_service=$(get_ssh_service)
+
+	if [ -z "$ssh_service" ]; then
+		echo "错误: 未找到 SSH 服务 (ssh/sshd)。" >&2
+		return 1
+	fi
+
+	systemctl restart "$ssh_service"
 }
 
 # [适配器] 开放指定端口
@@ -193,7 +351,8 @@ firewall_close_port() {
 		;;
 	"nftables")
 		# nftables 删除规则需要先找到规则的 handle
-		local handle=$(nft -a list ruleset | grep "dport $port" | grep "$protocol" | grep "accept" | awk '{print $NF}')
+		local handle
+		handle=$(nft -a list ruleset | grep "dport $port" | grep "$protocol" | grep "accept" | awk '{print $NF}')
 		if [ -n "$handle" ]; then
 			nft delete rule inet filter input handle "$handle"
 			# 尝试持久化规则
@@ -264,29 +423,24 @@ install_components() {
 
 	echo "正在安装必要组件..."
 
-	local pkg_manager=""
 	local update_cmd=""
 	local install_cmd=""
 
 	# 根据操作系统设置包管理器命令
 	case $OS_TYPE in
 	"Debian/Ubuntu")
-		pkg_manager="apt"
 		update_cmd="apt-get update -y"
 		install_cmd="apt-get install -y"
 		;;
 	"CentOS")
-		pkg_manager="yum"
 		update_cmd="yum update -y"
 		install_cmd="yum install -y"
 		;;
 	"Fedora")
-		pkg_manager="dnf"
 		update_cmd="dnf update -y"
 		install_cmd="dnf install -y"
 		;;
 	"Arch")
-		pkg_manager="pacman"
 		update_cmd="pacman -Syu --noconfirm"
 		install_cmd="pacman -S --noconfirm"
 		;;
@@ -316,17 +470,15 @@ install_components() {
 
 	# 使用加速镜像（如果已设置）安装 Docker
 	local docker_url="https://get.docker.com"
+	local docker_args=(--version 28)
 	if [ -n "${ACC}" ]; then
 		# 在国内使用 Docker 官方脚本时，通过 --mirror 选项指定镜像源
-		bash <(curl -sSL "${docker_url}") "${ACC} --version 28" || {
-			echo "使用镜像安装 Docker 失败"
-			return 1
-		}
-	else
-		bash <(curl -sSL "${docker_url}") --version 28 || {
-			echo "安装 Docker 失败"
-			return 1
-		}
+		docker_args=(--mirror AzureChinaCloud --version 28)
+	fi
+
+	if ! bash <(curl -sSL "${docker_url}") "${docker_args[@]}"; then
+		echo "安装 Docker 失败"
+		return 1
 	fi
 
 	echo "Docker 安装成功。"
@@ -450,10 +602,10 @@ add_public_keys() {
 
 # 关闭 SSH 的密码登录功能，强制使用密钥登录，提高安全性
 disable_ssh_password_login() {
-	local sshd_config="/etc/ssh/sshd_config"
+	local backup_dir
 
-	if [ ! -f "$sshd_config" ]; then
-		echo "错误: sshd_config 文件不存在于 $sshd_config"
+	if [ ! -f "$SSHD_CONFIG" ]; then
+		echo "错误: sshd_config 文件不存在于 $SSHD_CONFIG"
 		return 1
 	fi
 
@@ -465,24 +617,24 @@ disable_ssh_password_login() {
 
 	echo "正在关闭SSH密码登录..."
 
-	# 备份原始 sshd_config 文件
-	cp "$sshd_config" "${sshd_config}.bak"
+	backup_dir=$(backup_ssh_state)
+	ensure_sshd_dropin_include
+	write_ssh_managed_config "" "no"
 
-	# 使用 sed 修改配置
-	# s/^[#\s]*PasswordAuthentication\s\+.*/PasswordAuthentication no/g
-	# 这个正则表达式会匹配行首任意数量的#和空格，然后是 "PasswordAuthentication" 和任意空格，最后是任意字符
-	# 并将其替换为 "PasswordAuthentication no"
-	sed -i 's/^[#\s]*PasswordAuthentication\s\+.*/PasswordAuthentication no/g' "$sshd_config"
-	# 确保 ChallengeResponseAuthentication 也被禁用
-	sed -i 's/^[#\s]*ChallengeResponseAuthentication\s\+.*/ChallengeResponseAuthentication no/g' "$sshd_config"
+	if ! validate_ssh_config || ! verify_ssh_password_disabled; then
+		echo "错误: SSH 配置校验失败。正在恢复配置..."
+		restore_ssh_state "$backup_dir"
+		return 1
+	fi
 
-	# 重启 sshd 服务以应用更改
-	if systemctl restart sshd; then
+	# 重启 SSH 服务以应用更改
+	if restart_ssh_service; then
 		echo "SSH密码登录已成功关闭。"
 	else
-		echo "错误: SSH服务重启失败。请检查 'systemctl status sshd' 获取详情。"
-		echo "正在从备份恢复 sshd_config 文件..."
-		mv "${sshd_config}.bak" "$sshd_config"
+		echo "错误: SSH服务重启失败。请检查 'systemctl status sshd' 或 'systemctl status ssh' 获取详情。"
+		echo "正在恢复 SSH 配置..."
+		restore_ssh_state "$backup_dir"
+		restart_ssh_service >/dev/null 2>&1
 		return 1
 	fi
 }
@@ -506,21 +658,46 @@ add_docker_tools() {
 
 # 删除所有 swap 文件和分区
 remove_all_swap() {
-	# 获取所有 swap 文件的列表
-	swap_files=$(swapon -s | awk '{if($1!~"^Filename"){print $1}}')
+	local swap_items=()
+	local item
+	local fstab_backup=""
+	local tmp_fstab
 
-	# 获取所有 swap 分区的列表
-	swap_partitions=$(grep -E '^\S+\s+\S+\sswap\s+' /proc/swaps | awk '{print $1}')
+	mapfile -t swap_items < <(awk 'NR > 1 {print $1}' /proc/swaps | sort -u)
 
-	# 遍历并禁用、删除每个 swap 文件和分区
-	for item in $swap_files $swap_partitions; do
-		echo "正在禁用并删除 swap ：$item"
-		swapoff "$item"
-		rm -f "$item"
-		echo "已删除 swap ：$item"
+	if [ ${#swap_items[@]} -eq 0 ]; then
+		echo "未检测到活动 swap。"
+		return 0
+	fi
+
+	if [ -f /etc/fstab ]; then
+		fstab_backup="/etc/fstab.bak.$(date +%Y%m%d_%H%M%S)"
+		cp /etc/fstab "$fstab_backup"
+		echo "已备份 /etc/fstab 到 $fstab_backup"
+	fi
+
+	for item in "${swap_items[@]}"; do
+		echo "正在禁用 swap：$item"
+		swapoff "$item" || {
+			echo "警告：禁用 swap 失败：$item"
+			continue
+		}
+
+		if [ -f "$item" ] && [ ! -b "$item" ]; then
+			rm -f "$item"
+			echo "已删除 swap 文件：$item"
+		else
+			echo "已禁用 swap 设备：$item（未删除设备节点）"
+		fi
+
+		if [ -f /etc/fstab ]; then
+			tmp_fstab=$(mktemp)
+			awk -v target="$item" '$1 != target {print}' /etc/fstab >"$tmp_fstab"
+			mv "$tmp_fstab" /etc/fstab
+		fi
 	done
 
-	echo "所有 swap 文件和分区已删除。"
+	echo "swap 处理完成。"
 }
 
 # 清理 swap 缓存
@@ -834,9 +1011,9 @@ uninstall_debian_cloud_kernel() {
 }
 # 修改SSH端口号
 modify_ssh_port() {
-	local sshd_config="/etc/ssh/sshd_config"
-	local current_port
-	current_port=$(grep -i "^\s*port" "$sshd_config" | awk '{print $2}' | tail -n 1)
+	local current_port opened_new_port=false
+	local backup_dir
+	current_port=$(dump_effective_ssh_config 2>/dev/null | awk '$1 == "port" {print $2; exit}')
 
 	if [ -z "$current_port" ]; then
 		current_port=22 # 默认端口
@@ -851,25 +1028,31 @@ modify_ssh_port() {
 	fi
 
 	echo "正在修改 SSH 端口为 $new_port..."
-	# 备份配置文件
-	cp "$sshd_config" "${sshd_config}.bak"
-	# 修改或添加 Port 配置
-	if grep -q "^\s*Port" "$sshd_config"; then
-		sed -i "s/^\s*Port.*/Port $new_port/" "$sshd_config"
-	else
-		echo "Port $new_port" >>"$sshd_config"
+	backup_dir=$(backup_ssh_state)
+	ensure_sshd_dropin_include
+	write_ssh_managed_config "$new_port" "keep"
+
+	if ! validate_ssh_config || ! verify_ssh_port_effective "$new_port"; then
+		echo "错误：SSH 配置校验失败，操作已回滚。"
+		restore_ssh_state "$backup_dir"
+		return 1
 	fi
 
-	# # 开放新端口
-	# firewall_open_port "$new_port" "tcp"
-	# if [ $? -ne 0 ]; then
-	#     echo "错误：在防火墙中开放新端口失败，操作已回滚。"
-	#     mv "${sshd_config}.bak" "$sshd_config"
-	#     return 1
-	# fi
+	# 先开放新端口，再重启 SSH，降低远程服务器断联风险。
+	if [ "$FIREWALL_TYPE" != "unknown" ]; then
+		if firewall_open_port "$new_port" "tcp"; then
+			opened_new_port=true
+		else
+			echo "错误：在防火墙中开放新端口失败，操作已回滚。"
+			restore_ssh_state "$backup_dir"
+			return 1
+		fi
+	else
+		echo "警告：未检测到支持的防火墙，跳过自动开放端口。"
+	fi
 
 	# 重启 SSH 服务
-	if systemctl restart sshd; then
+	if restart_ssh_service; then
 		echo "SSH 端口修改成功，新端口为 $new_port。"
 		echo "请记得使用新端口重新连接！"
 		# # 如果旧端口不是22，则可以选择关闭
@@ -881,8 +1064,11 @@ modify_ssh_port() {
 		# fi
 	else
 		echo "错误：SSH 服务重启失败。操作已回滚。"
-		mv "${sshd_config}.bak" "$sshd_config"
-		# firewall_close_port "$new_port" "tcp" # 回滚防火墙规则
+		restore_ssh_state "$backup_dir"
+		if [ "$opened_new_port" = true ] && [ "$new_port" != "$current_port" ]; then
+			firewall_close_port "$new_port" "tcp"
+		fi
+		restart_ssh_service >/dev/null 2>&1
 		return 1
 	fi
 }
@@ -1237,7 +1423,7 @@ display_menu() {
 	if [[ "$OS_TYPE" == "Debian/Ubuntu" ]]; then
 		echo -e "----------- ${BOLD}内核管理 (Debian/Ubuntu)${RESET} -------------"
 		echo -e "${GREEN} 14${RESET}      安装 XanMod 内核 (含BBRv3)"
-		echo -e "${GREEN} 16${RESET}      卸载 XanMod 内核"
+		echo -e "${GREEN} 15${RESET}      卸载 XanMod 内核"
 		if [[ $(grep -i "debian" /etc/os-release) ]]; then
 			echo -e "${GREEN} 16${RESET}      安装 Debian Cloud 内核"
 			echo -e "${GREEN} 17${RESET}      卸载 Debian Cloud 内核"

--- a/set_dns_via_dhclient.sh
+++ b/set_dns_via_dhclient.sh
@@ -30,11 +30,29 @@ CUSTOM_DNS_COMMENT="# Custom DNS servers added by script (set_dns_via_dhclient.s
 
 # --- 脚本主体 ---
 
-# 1. 检查 dhclient.conf 文件是否存在
+# 1. 确认当前系统具备 dhclient 配置环境
+if ! command -v dhclient &>/dev/null; then
+  echo "❌ 错误：未检测到 dhclient。此脚本仅适用于使用 dhclient 的系统。"
+  exit 1
+fi
+
+if [ ! -d "$(dirname "$DHCLIENT_CONF")" ]; then
+  echo "❌ 错误：未检测到 /etc/dhcp 目录，无法确认系统使用 dhclient。"
+  exit 1
+fi
+
+if command -v systemctl &>/dev/null && systemctl is-active --quiet systemd-resolved; then
+  echo "❌ 错误：检测到 systemd-resolved 正在运行，当前系统可能不使用 dhclient 管理 DNS。"
+  echo "请使用 systemd-resolved 或 NetworkManager 对应的 DNS 配置方式。"
+  exit 1
+fi
+
 if [ ! -f "$DHCLIENT_CONF" ]; then
-  echo "⚠️  警告：配置文件 ${DHCLIENT_CONF} 不存在。"
-  echo "正在尝试创建一个最小化的配置文件..."
-  touch "$DHCLIENT_CONF"
+  echo "⚠️  配置文件 ${DHCLIENT_CONF} 不存在，将创建一个新的 dhclient 配置文件。"
+  touch "$DHCLIENT_CONF" || {
+    echo "❌ 错误：无法创建 ${DHCLIENT_CONF}。"
+    exit 1
+  }
 fi
 
 # 2. 备份原始配置文件 (如果尚未备份)
@@ -74,30 +92,14 @@ echo "➕ 正在添加新的 DNS 配置..."
 
 echo "✅ 配置文件修改完成。"
 
-# 4. 应用网络配置
-echo "🔄 正在重新应用网络配置以使 DNS 生效..."
-# 这会短暂中断网络连接，通常几秒钟内恢复
-# 首先尝试重启 networking.service，这是Debian的经典方式
-if command -v systemctl &> /dev/null && systemctl is-active networking.service &> /dev/null; then
-    systemctl restart networking.service
-    sleep 3 # 等待网络稳定
-else
-    # 如果 networking.service 不可用，尝试用 ifupdown 重启主接口
-    INTERFACE=$(ip -4 route ls | grep default | grep -Eo 'dev [^ ]+' | awk '{print $2}' | head -n1)
-    if [ -n "$INTERFACE" ] && command -v ifdown &> /dev/null && command -v ifup &> /dev/null; then
-        echo "检测到主网络接口为: ${INTERFACE}。正在使用 ifdown/ifup 重启..."
-        ifdown "$INTERFACE" && ifup "$INTERFACE"
-        sleep 5 # 等待更长时间，因为 ifup/ifdown 可能更慢
-    else
-        echo "⚠️  警告: 无法自动重启网络服务。"
-        echo "👉 请手动重启VPS ('sudo reboot') 来应用更改。"
-    fi
-fi
+# 4. 应用提示
+echo "✅ DNS 配置已写入 dhclient.conf。"
+echo "⚠️  为避免远程服务器断网，脚本不会自动重启 networking 或执行 ifdown/ifup。"
+echo "👉 请在确认有备用连接后，手动续租 DHCP 或重启服务器使配置生效。"
 
-chmod 644 /etc/resolv.conf
 # 5. 验证结果
 echo "-----------------------------------------------------"
-echo "🎉 配置完成！正在验证..."
+echo "🎉 配置完成！当前 /etc/resolv.conf 可能要在 DHCP 续租后才会变化。"
 
 if [ -f "/etc/resolv.conf" ]; then
     echo "
@@ -119,4 +121,4 @@ else
     echo "❌ 错误: /etc/resolv.conf 文件未找到。配置可能未生效。"
 fi
 
-echo -e "\n✨ 脚本执行完毕。如果验证成功，您的 DNS 已被修改，并且重启后依然有效。"
+echo -e "\n✨ 脚本执行完毕。配置将在 dhclient 重新获取租约后生效。"


### PR DESCRIPTION
## Summary
- harden SSH password/port changes with managed drop-in config and effective sshd validation
- make swap removal safer, avoid network restarts in DNS setup, and move Fail2ban SSH jail into jail.d
- validate kernel tuning inputs, roll back failed sysctl applies, fix Docker install args, and improve Docker helper commands/completion

## Verification
- bash -n server-setup.sh add_docker_tools.sh configure_fail2ban.sh manage_xanmod_kernel.sh optimize_kernel_parameters.sh set_dns_via_dhclient.sh docker_tools/*.sh
- shellcheck -S warning server-setup.sh add_docker_tools.sh configure_fail2ban.sh manage_xanmod_kernel.sh optimize_kernel_parameters.sh set_dns_via_dhclient.sh docker_tools/*.sh
- git diff --check
- simulated dlogs/dexec container completion test
